### PR TITLE
(#39) Use Newtonsoft.Json in Elasticsearch deserialization.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -76,6 +76,16 @@ jobs:
     name: Run Integration Tests (on Linux)
     runs-on: ubuntu-latest
     needs: test_build_release
+    services:
+      elasticsearch:
+        image: elasticsearch:7.9.2
+        env:
+          ## Pass elasticsearch options via environment variables.
+          discovery.type: single-node
+        ports:
+          ## NOTE: This will be exposed as a random port referenced below by job.services.elasticsearch.ports[9200]
+          - 9200/tcp
+        options: --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
 
     steps:
       - uses: actions/checkout@v2
@@ -88,6 +98,15 @@ jobs:
         run: |
               ## Create test output and API logging location
               mkdir -p integration-tests/target
+      - name: Load Data into elasticsearch & prepare for tests
+        env:
+          ELASTIC_SEARCH_HOST: http://localhost:${{ job.services.elasticsearch.ports[9200] }}
+        run: |
+              ## Create test output and API logging location
+              mkdir -p integration-tests/target
+
+              ## Load the elasticsearch data
+              ./integration-tests/bin/load-integration-data.sh
         # This project doesn't create an API as a deliverable artifact. In order to test the shared
         # API components, we have to create an API specifically for testing, which means it also has
         # to be built for the express purpose of running the integration tests.
@@ -96,6 +115,7 @@ jobs:
               dotnet publish -c Release -o $GITHUB_WORKSPACE/built-api test/integration-test-harness/
       - name: Start API
         env:
+          Elasticsearch__Servers: http://localhost:${{ job.services.elasticsearch.ports[9200] }}
           ASPNETCORE_LOGGING__CONSOLE__DISABLECOLORS: true
           API_URL: http://localhost:5000
           SLEEP_TIMEOUT: 5

--- a/integration-tests/bin/load-integration-data.sh
+++ b/integration-tests/bin/load-integration-data.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+## Use the Environment var or the default
+if [[ -z "${ELASTIC_SEARCH_HOST}" ]]; then
+    ELASTIC_HOST="http://localhost:9200"
+else
+    ELASTIC_HOST=${ELASTIC_SEARCH_HOST}
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+## Wait until docker is up.
+echo "Waiting for ES Service at ${ELASTIC_HOST} to Start"
+until $(curl --output /dev/null --silent --head --fail "${ELASTIC_HOST}"); do
+    printf '.'
+    sleep 1
+done
+echo "ES Service is up"
+
+# First wait for ES to start...
+response=$(curl --write-out %{http_code} --silent --output /dev/null "${ELASTIC_HOST}")
+
+until [ "$response" = "200" ]; do
+    response=$(curl --write-out %{http_code} --silent --output /dev/null "${ELASTIC_HOST}")
+    >&2 echo "Elastic Search is unavailable - sleeping"
+    sleep 1
+done
+
+# next wait for ES status to turn to Green
+health_check="curl -fsSL ${ELASTIC_HOST}/_cat/health?h=status"
+health=$(eval $health_check)
+echo "Waiting for ES status to be ready"
+until [[ "$health" = 'green' ]]; do
+    >&2 echo "Elastic Search is unavailable - sleeping"
+    sleep 10
+    health=$(eval $health_check)
+done
+echo "ES status is green"
+
+pushd $DIR/../data/source
+echo "Load the index mappings"
+MAPPING_LOAD_CMD="curl -fsS -H \"Content-Type: application/x-ndjson\" -XPUT ${ELASTIC_HOST}/test-index-v1 --data-binary \"@test-index-mapping.json\""
+mapping_output=$(eval $MAPPING_LOAD_CMD)
+echo $mapping_output
+
+echo "Load the records"
+BULK_LOAD_CMD="curl -fsS -H \"Content-Type: application/x-ndjson\" -XPOST ${ELASTIC_HOST}/_bulk --data-binary \"@test-index-data.jsonl\""
+load_output=$(eval $BULK_LOAD_CMD)
+
+## Test to make sure we loaded items
+## TODO: Actually check for errors.
+echo $load_output | wc -l
+
+
+popd

--- a/integration-tests/data/source/test-index-data.jsonl
+++ b/integration-tests/data/source/test-index-data.jsonl
@@ -1,0 +1,4 @@
+{"index": {"_index": "test-index-v1", "_id": "simple-string"}}
+{"default": "Default serialization", "custom": "simple-string-value"}
+{"index": {"_index": "test-index-v1", "_id": "has-array"}}
+{"default": "Default serialization", "custom": ["first-string-value", "second-string-value"]}

--- a/integration-tests/data/source/test-index-mapping.json
+++ b/integration-tests/data/source/test-index-mapping.json
@@ -1,0 +1,15 @@
+{
+  "settings": {
+    "number_of_shards": 1
+  },
+  "mappings": {
+    "properties": {
+      "default": {
+        "type": "keyword"
+      },
+      "custom": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/integration-tests/docker-nciocpl-api-common/api/build/appsettings.inttest.json
+++ b/integration-tests/docker-nciocpl-api-common/api/build/appsettings.inttest.json
@@ -4,5 +4,11 @@
             "Default": "Warning"
         }
     },
-    "AllowedHosts": "*"
+    "AllowedHosts": "*",
+    "Elasticsearch": {
+      "Servers": "http://elasticsearch:9200",
+      "Userid": "",
+      "Password": "",
+      "EnableDebugging": false
+    }
 }

--- a/integration-tests/docker-nciocpl-api-common/docker-compose.yml
+++ b/integration-tests/docker-nciocpl-api-common/docker-compose.yml
@@ -1,6 +1,25 @@
 version: "3.7"
 
 services:
+    elasticsearch:
+        image: elasticsearch:7.9.2
+        ## All of the ES settings can be set via the environment
+        ## vars.
+        environment:
+            - discovery.type=single-node
+            - ES_JAVA_OPTS=-Xms750m -Xmx750m
+        ## These exposed ports are for debugging only. .NET +
+        ## Docker + MacOS == bad scene. (.NET always wants to
+        ## use the hosts name, and on a mac that is actually
+        ## a virtual machine, and not on the same network.)
+        ports:
+            - "9200:9200"
+            - "9300:9300"
+        networks:
+            api-common:
+                aliases:
+                    - elasticsearch
+
     api:
         build:
             ## We need the context of our build to be the root of the
@@ -15,9 +34,11 @@ services:
         ## for elasticsearch to be running, just that the
         ## elasticsearch container should be running first.
         networks:
-            listingpagesapi:
+            api-common:
                 aliases:
                     - api
+        depends_on:
+          - elasticsearch
 
     ## Commenting out the test container as there seem to be some
     ## performance issues with Karate + API + ES running in docker.
@@ -34,7 +55,7 @@ services:
     #     ## for elasticsearch to be running, just that the
     #     ## elasticsearch container should be running first.
     #     networks:
-    #         listingpagesapi:
+    #         api-common:
     #             aliases:
     #                 - tester
     #     depends_on:
@@ -42,4 +63,4 @@ services:
     #         - api
 
 networks:
-  listingpagesapi:
+  api-common:

--- a/integration-tests/features/default-route/custom-serialization.feature
+++ b/integration-tests/features/default-route/custom-serialization.feature
@@ -1,0 +1,28 @@
+Feature: The API library allows for custom deserialization of data retrieved from Elasticsearch.
+
+  Background:
+    * url apiHost
+
+  Scenario Outline: Fields which use default serialization are unaffected.
+
+    Given path 'test/custom-serialization/', identifier
+    When method get
+    Then status 200
+    And match each $.[*].default == 'Default serialization'
+
+    Examples:
+      | identifier    |
+      | simple-string |
+      | has-array     |
+
+  Scenario Outline: Fields which use custom serialization can have special handling.
+
+    Given path 'test/custom-serialization/', identifier
+    When method get
+    Then status 200
+    And match $.custom == expected
+
+    Examples:
+      | identifier    | expected                 |
+      | simple-string | Took the string path     |
+      | has-array     | Took the not string path |

--- a/src/NCI.OCPL.Api.Common.Testing/ElasticTools.cs
+++ b/src/NCI.OCPL.Api.Common.Testing/ElasticTools.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Collections.Generic;
 
 using Elasticsearch.Net;
 using Nest;
+using Nest.JsonNetSerializer;
 
 namespace NCI.OCPL.Api.Common.Testing
 {
@@ -30,7 +30,7 @@ namespace NCI.OCPL.Api.Common.Testing
             // Setup ElasticSearch stuff using the contents of the JSON file as the client response.
             InMemoryConnection conn = new InMemoryConnection(responseBody);
 
-            var connectionSettings = new ConnectionSettings(pool, conn);
+            var connectionSettings = new ConnectionSettings(pool, conn, sourceSerializer: JsonNetSerializer.Default);
 
             return new ElasticClient(connectionSettings);
         }
@@ -54,7 +54,7 @@ namespace NCI.OCPL.Api.Common.Testing
           // Setup ElasticSearch stuff using the contents of the JSON file as the client response.
           InMemoryConnection conn = new InMemoryConnection(responseBody, statusCode);
 
-          var connectionSettings = new ConnectionSettings(pool, conn);
+          var connectionSettings = new ConnectionSettings(pool, conn, sourceSerializer: JsonNetSerializer.Default);
 
           return new ElasticClient(connectionSettings);
         }

--- a/src/NCI.OCPL.Api.Common.Testing/NCI.OCPL.Api.Common.Testing.csproj
+++ b/src/NCI.OCPL.Api.Common.Testing/NCI.OCPL.Api.Common.Testing.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
 
     <PackageDescription>Shared helper code for unit testing.</PackageDescription>
     <RepositoryUrl>https://github.com/NCIOCPL/NCI.OCPL.Api.Shared</RepositoryUrl>
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="NEST" Version="7.9.*" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.*" />
+    <PackageReference Include="NEST.JsonNetSerializer" Version="7.9.*" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.*" />
   </ItemGroup>
 </Project>

--- a/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
+++ b/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
 
     <PackageDescription>Common code for use between APIs.</PackageDescription>
     <RepositoryUrl>https://github.com/NCIOCPL/NCI.OCPL.Api.Shared</RepositoryUrl>
@@ -18,6 +18,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.*" />
 
     <PackageReference Include="NEST" Version="7.9.*" />
+    <PackageReference Include="NEST.JsonNetSerializer" Version="7.9.*" />
+
     <PackageReference Include="NSwag.AspNetCore" Version="13.11.*" />
   </ItemGroup>
 </Project>

--- a/src/NCI.OCPL.Api.Common/NciStartupBase.cs
+++ b/src/NCI.OCPL.Api.Common/NciStartupBase.cs
@@ -14,10 +14,9 @@ using Microsoft.Extensions.Hosting;
 using NCI.OCPL.Api.Common.Models.Options;
 
 using Nest;
+using Nest.JsonNetSerializer;
 using Elasticsearch.Net;
 
-using NSwag.AspNetCore;
-using NJsonSchema;
 
 namespace NCI.OCPL.Api.Common
 {
@@ -92,7 +91,7 @@ namespace NCI.OCPL.Api.Common
         var connectionPool = new SniffingConnectionPool(uris);
 
         //Return a new instance of an ElasticClient with our settings
-        ConnectionSettings settings = new ConnectionSettings(connectionPool);
+        ConnectionSettings settings = new ConnectionSettings(connectionPool, sourceSerializer: JsonNetSerializer.Default);
 
         //Let's only try and use credentials if the username is set.
         if (!string.IsNullOrWhiteSpace(username))

--- a/test/integration-test-harness/Controllers/TestController.cs
+++ b/test/integration-test-harness/Controllers/TestController.cs
@@ -1,0 +1,62 @@
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+using Nest;
+
+
+namespace integration_test_harness.Controllers
+{
+  /// <summary>
+  /// Controller for using in tests.
+  /// </summary>
+  [Route("test")]
+  public class TestController : ControllerBase
+  {
+    private readonly IElasticClient _elasticClient;
+
+    private readonly ESIndexOptions _indexConfig;
+
+    /// <summary>
+    /// Constructor.
+    /// <remarks>
+    /// DO NOT DO THIS!!! The ES client and setup options don't belong in a controller.
+    /// They're just here so we don't have to make the test any more complex than it
+    /// already needs to be.
+    /// </remarks>
+    /// </summary>
+    /// <param name="elasticClient">Elasticsearch client instance.</param>
+    /// <param name="config">Configuration/settings for the query.</param>
+    /// <returns></returns>
+    public TestController(IElasticClient elasticClient, IOptions<ESIndexOptions> config)
+      => (_elasticClient, _indexConfig) = (elasticClient, config.Value);
+
+    /// <summary>
+    /// Get an object which uses custom serialization.
+    /// </summary>
+    [HttpGet("custom-serialization/{identifier}")]
+    public async Task<CustomSerializationModel> CustomSerialization(string identifier)
+    {
+      // Again, don't put Elasticsearch queries into the controller. This is only being
+      // done in order to keep the test harness super-simple.
+      IndexName index = Indices.Index(this._indexConfig.AliasName);
+
+      IGetResponse<CustomSerializationModel> resp = null;
+
+      try
+      {
+          IGetRequest  req = new GetRequest(index, identifier);
+          resp = await _elasticClient.GetAsync<CustomSerializationModel>(req);
+      }
+      catch (System.Exception)
+      {
+
+          throw;
+      }
+
+
+      return resp.Source;
+    }
+  }
+}

--- a/test/integration-test-harness/Controllers/ValidRouteController.cs
+++ b/test/integration-test-harness/Controllers/ValidRouteController.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using NCI.OCPL.Api.Common;
 
-namespace NCI.OCPL.Api.Common.Controllers
+namespace integration_test_harness.Controllers
 {
   /// <summary>
   /// Controller for testing that the default route doesn't break known routes.

--- a/test/integration-test-harness/Models/CustomJsonConverter.cs
+++ b/test/integration-test-harness/Models/CustomJsonConverter.cs
@@ -1,0 +1,56 @@
+using System;
+
+using Newtonsoft.Json;
+
+namespace integration_test_harness
+{
+
+  /// <summary>
+  /// Converts a JSON element containing either a single string, or an array of strings, into
+  /// a single string.
+  /// </summary>
+  public class CustomJsonConverter : JsonConverter<string>
+  {
+    /// <summary>
+    /// Responsible for reading a JSON element containing either a single string or an array of strings
+    /// and converting it into a single string by discarding all but the first one.
+    /// </summary>
+    /// <param name="reader">The JsonReader to read from.</param>
+    /// <param name="objectType">Type of the destination object (always System.String).</param>
+    /// <param name="existingValue">The existing value of the destination object</param>
+    /// <param name="hasExistingValue">Boolean. Does the destination object already have a value?</param>
+    /// <param name="serializer">The calling serializer</param>
+    /// <returns></returns>
+    public override string ReadJson(JsonReader reader, Type objectType, string existingValue, bool hasExistingValue, JsonSerializer serializer)
+    {
+      // If it's just a string, return the value.
+      if (reader.ValueType == typeof(string))
+      {
+        return "Took the string path";
+      }
+      else
+      {
+        // Otherwise, save the first value and skip past the rest.
+        string value = reader.ReadAsString();
+        while (reader.ReadAsString() != null) ;
+        return "Took the not string path";
+      }
+    }
+
+    /// <summary>
+    /// Mark the converter as not being used for writing JSON.
+    /// </summary>
+    public override bool CanWrite => false;
+
+    /// <summary>
+    /// Writes the JSON representation of the object.
+    /// </summary>
+    /// <param name="writer">The JsonWriter to write to.</param>
+    /// <param name="value">The value.</param>
+    /// <param name="serializer">The calling serializer.</param>
+    public override void WriteJson(JsonWriter writer, string value, JsonSerializer serializer)
+    {
+      throw new NotImplementedException("This converter not intended for writing.");
+    }
+  }
+}

--- a/test/integration-test-harness/Models/CustomSerializationModel.cs
+++ b/test/integration-test-harness/Models/CustomSerializationModel.cs
@@ -1,0 +1,25 @@
+using Nest;
+using Newtonsoft.Json;
+
+namespace integration_test_harness
+{
+  /// <summary>
+  /// Demonstration of Elasticsearch serialization.
+  /// </summary>
+  public class CustomSerializationModel
+  {
+    /// <summary>
+    /// Property which uses default serialization.
+    /// </summary>
+    [Text(Name = "default")]
+    public string Default { get; set; }
+
+    /// <summary>
+    /// Property which uses custom serialization to convert an array
+    /// to a single value.
+    /// </summary>
+    [Text(Name = "custom")]
+    [JsonConverter(typeof(CustomJsonConverter))]
+    public string Custom { get; set; }
+  }
+}

--- a/test/integration-test-harness/Models/ESIndexOptions.cs
+++ b/test/integration-test-harness/Models/ESIndexOptions.cs
@@ -1,0 +1,14 @@
+namespace integration_test_harness
+{
+  /// <summary>
+  /// Elasticsearch options.
+  /// </summary>
+  public class ESIndexOptions
+  {
+    /// <summary>
+    /// Gets or sets the alias name for the Elasticsearch Collection we will use.
+    /// </summary>
+    /// <value>The name of the alias.</value>
+    public string AliasName { get; set; }
+  }
+}

--- a/test/integration-test-harness/Startup.cs
+++ b/test/integration-test-harness/Startup.cs
@@ -37,6 +37,7 @@ namespace integration_test_harness
     /// <param name="services">Services.</param>
     protected override void AddAdditionalConfigurationMappings(IServiceCollection services)
     {
+      services.Configure<ESIndexOptions>(Configuration.GetSection("TestIndexOptions"));
     }
 
     /// <summary>

--- a/test/integration-test-harness/appsettings.json
+++ b/test/integration-test-harness/appsettings.json
@@ -4,5 +4,14 @@
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "TestIndexOptions": {
+    "AliasName": "test-index-v1"
+  },
+  "Elasticsearch": {
+    "Servers": "http://localhost:9200",
+    "Userid": "",
+    "Password": "",
+    "EnableDebugging": false
+  }
 }

--- a/test/integration-test-harness/integration-test-harness.csproj
+++ b/test/integration-test-harness/integration-test-harness.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NEST" Version="7.9.*" />
     <ProjectReference Include="..\..\src\NCI.OCPL.Api.Common\NCI.OCPL.Api.Common.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
- Bump package version  numbers.
- Add integration test (not able to unit-test because of initialization and ES dependencies).
- Cleanup miscellaneous unused using statements.

Closes #39 