### PR TITLE
(#43) Upgrade to ES 7.17.5

### DIFF
--- a/integration-tests/docker-nciocpl-api-common/docker-compose.yml
+++ b/integration-tests/docker-nciocpl-api-common/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
     elasticsearch:
-        image: elasticsearch:7.9.2
+        image: elasticsearch:7.17.5
         ## All of the ES settings can be set via the environment
         ## vars.
         environment:


### PR DESCRIPTION
Upgrade to Elasticsearch 7.17.5 for security reasons.

Closes #43 