### PR TITLE
(#59) Make global.json available for publishing.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -280,10 +280,15 @@ jobs:
           name: ${{matrix.package}}-windows-latest
           path: ${{ github.workspace }}
 
+      - name: Download global.json
+        uses: actions/checkout@v4
+        with:
+          path: source
+
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          global-json-file: global.json
+          global-json-file: source/global.json
           source-url: "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/src/NCI.OCPL.Api.Common.Testing/NCI.OCPL.Api.Common.Testing.csproj
+++ b/src/NCI.OCPL.Api.Common.Testing/NCI.OCPL.Api.Common.Testing.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <Version>2.1.1</Version>
+    <Version>2.1.3</Version>
 
     <PackageDescription>Shared helper code for unit testing.</PackageDescription>
     <RepositoryUrl>https://github.com/NCIOCPL/NCI.OCPL.Api.Shared</RepositoryUrl>

--- a/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
+++ b/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <Version>2.1.1</Version>
+    <Version>2.1.3</Version>
 
     <PackageDescription>Common code for use between APIs.</PackageDescription>
     <RepositoryUrl>https://github.com/NCIOCPL/NCI.OCPL.Api.Shared</RepositoryUrl>


### PR DESCRIPTION
- Bumps package versions to 2.1.3.
- Put package version back in sync with release versions.

Closes #59