### PR TITLE
(#54) Switch to .Net 8

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,8 +31,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        # Run on macos 13 because there was no arm support in .Net 3.1.1
-        operating-system: [ubuntu-latest, windows-latest, macos-13]
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
         package: [NCI.OCPL.Api.Common, NCI.OCPL.Api.Common.Testing]
 
     steps:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "3.1.0"
+    "version": "8.0.0"
   }
 }

--- a/src/NCI.OCPL.Api.Common.Testing/NCI.OCPL.Api.Common.Testing.csproj
+++ b/src/NCI.OCPL.Api.Common.Testing/NCI.OCPL.Api.Common.Testing.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <Version>2.1.3</Version>
+    <Version>3.0.0</Version>
 
     <PackageDescription>Shared helper code for unit testing.</PackageDescription>
     <RepositoryUrl>https://github.com/NCIOCPL/NCI.OCPL.Api.Shared</RepositoryUrl>

--- a/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
+++ b/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <Version>2.1.3</Version>
+    <Version>3.0.0</Version>
 
     <PackageDescription>Common code for use between APIs.</PackageDescription>
     <RepositoryUrl>https://github.com/NCIOCPL/NCI.OCPL.Api.Shared</RepositoryUrl>

--- a/src/NCI.OCPL.Api.Common/NciStartupBase.cs
+++ b/src/NCI.OCPL.Api.Common/NciStartupBase.cs
@@ -217,7 +217,7 @@ namespace NCI.OCPL.Api.Common
             // we should remove this and test to see if it works without the hack.
             if (context.Request.Headers.ContainsKey("Origin"))
             {
-              context.Response.Headers.Add("Access-Control-Allow-Origin", "*");
+              context.Response.Headers["Access-Control-Allow-Origin"] = "*";
             }
 
             await context.Response.Body.WriteAsync(contents, 0, contents.Length);

--- a/test/NCI.OCPL.Api.Common.Testing.Tests/NCI.OCPL.Api.Common.Testing.Tests.csproj
+++ b/test/NCI.OCPL.Api.Common.Testing.Tests/NCI.OCPL.Api.Common.Testing.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/NCI.OCPL.Api.Common.Tests/NCI.OCPL.Api.Common.Tests.csproj
+++ b/test/NCI.OCPL.Api.Common.Tests/NCI.OCPL.Api.Common.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/integration-test-harness/integration-test-harness.csproj
+++ b/test/integration-test-harness/integration-test-harness.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Specify SDK v8.x
- Bump .net version in project files.
- Change nuget package versions to 3.0.0.
- Switch to setting header via indexer to resolve new warning message in NciStartupBase.
- Switch GHA builds to using macos-latest.

Closes #54