### PR TITLE
(#64, #65) Switch to Elasticsearch 7.17.28

### DIFF
--- a/.github/workflows/common-api-ci.yml
+++ b/.github/workflows/common-api-ci.yml
@@ -101,7 +101,7 @@ jobs:
     needs: test_build_release
     services:
       elasticsearch:
-        image: elasticsearch:7.17.5
+        image: elasticsearch:7.17.28
         env:
             discovery.type: single-node
             ES_JAVA_OPTS: -Xms750m -Xmx750m
@@ -123,7 +123,7 @@ jobs:
         shell: bash
         run: |
             if [[ -e 'integration-tests/bin/docker-setup.sh' ]]; then
-              CONTAINER_ID=$(docker ps -q --filter "ancestor=elasticsearch:7.17.5")
+              CONTAINER_ID=$(docker ps -q --filter "ancestor=elasticsearch:7.17.28")
               integration-tests/bin/docker-setup.sh $CONTAINER_ID
             fi
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -95,7 +95,7 @@ jobs:
     needs: test_build_release
     services:
       elasticsearch:
-        image: elasticsearch:7.17.5
+        image: elasticsearch:7.17.28
         env:
           ## Pass elasticsearch options via environment variables.
           discovery.type: single-node

--- a/integration-tests/bin/README.md
+++ b/integration-tests/bin/README.md
@@ -1,2 +1,2 @@
 # Karate tool
-This is Karate 0.9.5 downloaded from https://dl.bintray.com/ptrthomas/karate/.
+This is Karate 1.2.0 from https://github.com/karatelabs/

--- a/integration-tests/bin/logback.xml
+++ b/integration-tests/bin/logback.xml
@@ -8,7 +8,6 @@
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>${karate.output.dir}/karate.log</file>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>

--- a/integration-tests/docker-nciocpl-api-common/api/Dockerfile
+++ b/integration-tests/docker-nciocpl-api-common/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 COPY ./src /app/src
 COPY ./test /app/test
 COPY ./nci.ocpl.api.common.sln /app/app.sln
@@ -6,7 +6,7 @@ WORKDIR /app
 RUN dotnet publish -c Release -o /app/out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
 WORKDIR /app
 COPY --from=build-env /app/out .
 COPY ./integration-tests/docker-nciocpl-api-common/api/build/appsettings.inttest.json .

--- a/integration-tests/docker-nciocpl-api-common/docker-compose.yml
+++ b/integration-tests/docker-nciocpl-api-common/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     elasticsearch:
-        image: elasticsearch:7.17.5
+        image: elasticsearch:7.17.28
         ## All of the ES settings can be set via the environment
         ## vars.
         environment:

--- a/integration-tests/docker-nciocpl-api-common/docker-compose.yml
+++ b/integration-tests/docker-nciocpl-api-common/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
     elasticsearch:
         image: elasticsearch:7.17.5

--- a/integration-tests/features/health-check/health-check.feature
+++ b/integration-tests/features/health-check/health-check.feature
@@ -9,4 +9,4 @@ Feature: The library offers an ability to check the health of the Elasticsearch 
     Given path 'HealthCheck'
     When method GET
     Then status 200
-    And match response == true
+    And match response == 'true'


### PR DESCRIPTION
- Run shared workflow with Elasticsearch 7.17.28
- Update integration tests to Elasticsearch 7.17.28
- Update integration test API container to .Net 8.

Closes #64 
Fixes #65 
